### PR TITLE
HipChatClient.FormatMessageUri() url-escapes individual query parameters

### DIFF
--- a/HipChatClient/HipChatClient.cs
+++ b/HipChatClient/HipChatClient.cs
@@ -441,14 +441,14 @@ namespace HipChat
         private string FormatMessageUri(string message)
         {
             var url = string.Format(@"https://api.hipchat.com/v1/rooms/message?auth_token={0}&room_id={1}&format={2}&notify={3}&from={4}&message={5}&color={6}",
-                this.Token,
+                Uri.EscapeDataString(this.Token),
                 this.RoomId,
                 this.Format.ToString().ToLower(),
                 this.NotifyAsChar,
-                this.From,
-                message,
+				Uri.EscapeDataString(this.From),
+				Uri.EscapeDataString(message),
                 this.Color.ToString());
-            return Uri.EscapeUriString(url);
+            return url;
         }
 
         /// <summary>

--- a/HipChatClientTests/ClientTests.cs
+++ b/HipChatClientTests/ClientTests.cs
@@ -94,7 +94,14 @@ namespace HipChatClientTests
             client.SendMessage(MethodBase.GetCurrentMethod().Name);
         }
 
-        [TestMethod]
+		[TestMethod]
+		public void TestSendMessage_HtmlMessage()
+		{
+			var client = new HipChat.HipChatClient(defaultClient.Token, defaultClient.RoomId, defaultClient.From);
+			client.SendMessage(MethodBase.GetCurrentMethod().Name + " <a href='http://en.wikiquote.org/wiki/Pulp_Fiction#Dialogue'>Quotable &amp; questionable (?) gems from &quot;Pulp Fiction&quot;</a> =)");
+		}
+
+		[TestMethod]
         public void TestSendMessage_Message_Red()
         {
             var client = new HipChat.HipChatClient(defaultClient.Token, defaultClient.RoomId, defaultClient.From);


### PR DESCRIPTION
... instead of slamming them into a url string and encoding the result

it will now correctly handle author and message containing special url query string characters (? = & + % #)
